### PR TITLE
Add missing regexparam dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   ],
   "dependencies": {
     "lru-cache": "^6.0.0",
+    "regexparam": "^1.0.0",
     "trouter": "^3.2.0"
   }
 }


### PR DESCRIPTION
The missing dependency causes problems with package managers like pnpm that don't flatten the dependency tree.