### PR TITLE
Remove 'v' prefix in package.json version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "0http",
-  "version": "v3.5.1",
+  "version": "3.5.1",
   "description": "Cero friction HTTP request router. The need for speed!",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
It's not forbidden but very uncommon to have a `v` prefix in the `version` field. Remove it to avoid strange npm bugs like https://github.com/npm/cli/issues/6370.

Would appreciate a new publish after this bugfix.