### PR TITLE
Fixed issue that will crash CLI app that states `Trouter` is not a constructor

### DIFF
--- a/lib/router/sequential.js
+++ b/lib/router/sequential.js
@@ -1,4 +1,4 @@
-const Trouter = require('trouter')
+const { Trouter } = require('trouter')
 const next = require('./../next')
 const { LRUCache: LRU } = require('lru-cache')
 const { parse } = require('regexparam')

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "dependencies": {
     "lru-cache": "^10.2.0",
     "regexparam": "^3.0.0",
-    "trouter": "^3.2.1"
+    "trouter": "^4.0.0"
   },
   "types": "./index.d.ts"
 }


### PR DESCRIPTION
This fixes #39 