### PR TITLE
Fix async middleware errors

### DIFF
--- a/lib/next.js
+++ b/lib/next.js
@@ -48,11 +48,17 @@ function next (middlewares, req, res, index, routers, defaultRoute, errorHandler
       }
 
       // Call router's lookup method
-      return middleware.lookup(req, res, step)
+      const result = middleware.lookup(req, res, step)
+      return result && typeof result.then === 'function'
+        ? result.catch(err => errorHandler(err, req, res))
+        : result
     }
 
     // Regular middleware function
-    return middleware(req, res, step)
+    const result = middleware(req, res, step)
+    return result && typeof result.then === 'function'
+      ? result.catch(err => errorHandler(err, req, res))
+      : result
   } catch (err) {
     return errorHandler(err, req, res)
   }

--- a/tests/router-coverage.test.js
+++ b/tests/router-coverage.test.js
@@ -366,6 +366,21 @@ describe('0http - Router Coverage', () => {
       expect(res.error).to.equal('Middleware exception')
     })
 
+    it('should handle async middleware rejections', async () => {
+      const req = {}
+      const res = {}
+      const middleware = async (req, res, next) => {
+        throw new Error('Async failure')
+      }
+      const defaultRoute = () => {}
+      const errorHandler = (err, req, res) => {
+        res.error = err.message
+      }
+
+      await next([middleware], req, res, 0, {}, defaultRoute, errorHandler)
+      expect(res.error).to.equal('Async failure')
+    })
+
     it('should handle nested router without pattern', () => {
       const req = { url: '/test', path: '/test' }
       const res = {}


### PR DESCRIPTION
## Summary
- handle Promise rejections from middleware
- test async middleware error handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a805bbfa88323a8f845b09662ccca