### PR TITLE
Add array middleware registration test

### DIFF
--- a/lib/router/sequential.js
+++ b/lib/router/sequential.js
@@ -80,7 +80,7 @@ module.exports = (config = {}) => {
       middlewares = [prefix, ...middlewares]
       prefix = '/'
     }
-    _use.call(router, prefix, middlewares)
+    _use.call(router, prefix, ...middlewares)
 
     // Optimized nested router detection - check first middleware only
     const firstMiddleware = middlewares[0]

--- a/tests/middleware-registration.test.js
+++ b/tests/middleware-registration.test.js
@@ -59,6 +59,25 @@ describe('0http - Middlewares Registration', () => {
       })
   })
 
+  it('should support array-based middleware registration', async () => {
+    router.use('/arr', [m2, m3])
+
+    router.get('/arr/hello', (req, res, next) => {
+      res.end(JSON.stringify(res.body))
+    })
+
+    await request(baseUrl)
+      .get('/arr/hello')
+      .expect(200)
+      .then((response) => {
+        const payload = JSON.parse(response.text)
+
+        expect(payload[0]).to.equal('m1')
+        expect(payload[1]).to.equal('m2')
+        expect(payload[2]).to.equal('m3')
+      })
+  })
+
   it('should successfully terminate the service', async () => {
     server.close()
   })


### PR DESCRIPTION
## Summary
- support passing middleware arrays to `router.use`
- test middleware registration with array syntax

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a85d4816c8323b7737d74e0888938