### PR TITLE
Fix nested routers typo

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -138,7 +138,7 @@ router.get('/sayhi', (req, res) => {
 ```
 
 ### Nested Routers
-You can simply use `sequential` router intances as nested routers:
+You can simply use `sequential` router instances as nested routers:
 ```js
 const zero = require('../index')
 const { router, server } = zero({})


### PR DESCRIPTION
## Summary
- fix typo "intances" -> "instances" in docs/README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a85ac735c8323bf3159a89c1b83bb