### PR TITLE
fix: honor prioRequestsProcessing default and stop sharing cached params

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,12 +2,15 @@ const http = require('http')
 const httpServer = http.Server
 const httpsServer = require('https').Server
 
-module.exports = (config = { prioRequestsProcessing: true }) => {
+module.exports = (config = {}) => {
   const router = config.router || require('./lib/router/sequential')(config)
   const server = config.server || http.createServer()
 
+  // Default to true even when a partial config is provided. Keeping the default
+  // in the parameter alone would silently flip it off for any `zero({ ... })` call.
+  const prioRequestsProcessing = config.prioRequestsProcessing ?? true
   server.prioRequestsProcessing =
-    config.prioRequestsProcessing && (server instanceof httpServer || server instanceof httpsServer)
+    prioRequestsProcessing && (server instanceof httpServer || server instanceof httpsServer)
 
   if (server.prioRequestsProcessing) {
     server.on('request', (req, res) => {

--- a/lib/router/sequential.js
+++ b/lib/router/sequential.js
@@ -160,8 +160,10 @@ module.exports = (config = {}) => {
 
       // Optimized parameter assignment with minimal overhead
       if (!req.params) {
-        // Use pre-created empty object or provided params directly
-        req.params = params || Object.create(null)
+        // Shallow-copy: the match (and its params) may be served from the LRU
+        // cache and shared across all requests to the same method+path.
+        // Assigning by reference would let a middleware mutation leak between requests.
+        req.params = params ? { ...params } : Object.create(null)
       } else if (params) {
         // Manual property copying - optimized for small objects
         // Pre-compute keys and length to avoid repeated calls

--- a/tests/regression-findings.test.js
+++ b/tests/regression-findings.test.js
@@ -1,0 +1,74 @@
+/* global describe, it */
+const expect = require('chai').expect
+const request = require('supertest')
+
+/**
+ * Regression tests for two findings:
+ *
+ *  #1 prioRequestsProcessing default flips OFF whenever ANY config object is
+ *     passed without the flag, contradicting the documented `default: true`.
+ *
+ *  #2 The route-match cache stores trouter's `match` object (including its
+ *     `params`). On a cache hit `req.params` is assigned that object BY
+ *     REFERENCE, so all requests to the same method+path share one mutable
+ *     object — a non-idempotent middleware mutation bleeds into later requests.
+ */
+describe('0http - Regression: findings validation', () => {
+  describe('#1 prioRequestsProcessing default', () => {
+    it('should default prioRequestsProcessing to true when omitted but other config is provided', (done) => {
+      // A real-world call: user customizes the router but does NOT mention the flag.
+      const { server } = require('../index')({
+        router: require('../lib/router/sequential')()
+      })
+
+      // Documented default is `true`; passing unrelated config must not flip it off.
+      expect(server.prioRequestsProcessing).equals(true)
+      done()
+    })
+
+    it('should still honor an explicit false', (done) => {
+      const { server } = require('../index')({
+        prioRequestsProcessing: false,
+        router: require('../lib/router/sequential')()
+      })
+
+      expect(server.prioRequestsProcessing).equals(false)
+      done()
+    })
+  })
+
+  describe('#2 cached params are not shared across requests', () => {
+    const baseUrl = `http://localhost:${~~process.env.PORT + 1}`
+    const { router, server } = require('../index')({
+      router: require('../lib/router/sequential')()
+    })
+
+    it('should start the service', (done) => {
+      // Non-idempotent mutation: append a marker to req.params.id on every request.
+      router.get('/item/:id', (req, res) => {
+        req.params.id = req.params.id + '!'
+        res.end(req.params.id)
+      })
+
+      server.listen(~~process.env.PORT + 1, () => done())
+    })
+
+    it('should not leak a mutated param into the next request to the same path', async () => {
+      // First hit: 'x' -> 'x!'
+      const first = await request(baseUrl).get('/item/x').expect(200)
+      expect(first.text).to.equal('x!')
+
+      // Second hit to the SAME path: must also be 'x!', NOT 'x!!'.
+      const second = await request(baseUrl).get('/item/x').expect(200)
+      expect(second.text).to.equal('x!')
+
+      // Third hit, to be sure it does not keep growing.
+      const third = await request(baseUrl).get('/item/x').expect(200)
+      expect(third.text).to.equal('x!')
+    })
+
+    it('should stop the service', async () => {
+      server.close()
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Two correctness bugs found during a code review of the router core, each **validated by a regression test that fails on `master` and passes with the fix**.

### #1 — `prioRequestsProcessing` default silently disabled by any config (`index.js`)

The documented `default: true` lived only in the parameter default:

```js
module.exports = (config = { prioRequestsProcessing: true }) => { ... }
```

That default only applies to the **zero-arg** call. Any real-world call that passes config — `zero({ router })`, `zero({ errorHandler })`, `zero({ server })` — leaves `config.prioRequestsProcessing` as `undefined` (falsy), so the optimization is silently turned **off**, contradicting the docs/landing-page config table.

The existing `prio-request-processing.test.js` never caught this because all three cases pass the flag explicitly.

**Fix:** resolve inside the body — `const prioRequestsProcessing = config.prioRequestsProcessing ?? true`.

### #2 — Cached `params` shared by reference across requests (`lib/router/sequential.js`)

`router.lookup` caches trouter's whole `match` object (including its `params`) in the LRU cache (on by default, `cacheSize = -1`). On a cache hit it assigned `req.params = params` **by reference**, so every request to the same `method+path` shared one mutable object. A non-idempotent middleware mutation bled into later requests.

Demonstrated by the new test: a handler doing `req.params.id = req.params.id + '!'` on route `/item/:id` returns `x!` on the first hit but `x!!` on the second (shared object) before the fix.

**Fix:** shallow-copy on assignment — `req.params = params ? { ...params } : Object.create(null)`. The pre-existing `else if (params)` branch already copied into an existing `req.params`, so only the direct-assignment path needed the change.

## Validation

- New `tests/regression-findings.test.js` — both tests **fail on `master`** (`expected undefined to equal true`; `expected 'x!!' to equal 'x!'`) and **pass with the fix**.
- Full suite: **69 passing** (was 64), coverage **97%** (gate is 85%).
- `standard` lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)