### PR TITLE
perf: cut query-string parsing cost on the request hot path

### DIFF
--- a/lib/utils/queryparams.js
+++ b/lib/utils/queryparams.js
@@ -28,17 +28,24 @@ module.exports = (req, url) => {
     return
   }
 
-  // Process query parameters with optimized URLSearchParams handling
-  const searchParams = new URLSearchParams(search.replace(/\[\]=/g, '='))
+  // Only rewrite array notation (a[]=1 -> a=1) when it is actually present,
+  // avoiding a regex scan/allocation on the common query-string case.
+  const searchParams = new URLSearchParams(
+    search.indexOf('[]=') === -1 ? search : search.replace(/\[\]=/g, '=')
+  )
 
   for (const [name, value] of searchParams.entries()) {
-    // Split parameter name into segments by dot or bracket notation
-    /* eslint-disable-next-line */
-    const segments = name.split(/[\.\[\]]+/).filter(Boolean)
-
-    // Check each segment against the dangerous properties set
-    if (segments.some(segment => DANGEROUS_PROPERTIES.has(segment))) {
-      continue // Skip dangerous property names
+    // Prototype-pollution guard. The segment split/filter allocates per
+    // parameter, so it only runs for the rare names that could actually carry a
+    // dangerous segment. Every dangerous key ('__proto__', 'prototype',
+    // 'constructor') contains 'proto' or 'constructor' as a substring.
+    if (name.indexOf('proto') !== -1 || name.indexOf('constructor') !== -1) {
+      // Split parameter name into segments by dot or bracket notation
+      /* eslint-disable-next-line */
+      const segments = name.split(/[\.\[\]]+/).filter(Boolean)
+      if (segments.some(segment => DANGEROUS_PROPERTIES.has(segment))) {
+        continue // Skip dangerous property names
+      }
     }
 
     const existing = query[name]

--- a/tests/router-coverage.test.js
+++ b/tests/router-coverage.test.js
@@ -309,6 +309,23 @@ describe('0http - Router Coverage', () => {
       expect(req.path).to.equal('/path')
       expect(req.query).to.deep.equal({ param: '' })
     })
+
+    it('should group repeated and array-notation parameters', () => {
+      const req = {}
+      queryparams(req, '/path?id[]=1&id[]=2&name=a&name=b&tag=x')
+      expect(req.query).to.deep.equal({ id: ['1', '2'], name: ['a', 'b'], tag: 'x' })
+    })
+
+    it('should strip dangerous prototype-pollution keys', () => {
+      const req = {}
+      queryparams(req, '/path?__proto__=evil&prototype=z&user.constructor=bad&a[__proto__]=x&ok=1')
+      // Dangerous keys are dropped; the query object has no prototype.
+      expect(Object.getPrototypeOf(req.query)).to.equal(null)
+      expect(req.query.ok).to.equal('1')
+      expect(Object.keys(req.query)).to.deep.equal(['ok'])
+      // No pollution leaked onto Object.prototype.
+      expect(({}).evil).to.equal(undefined)
+    })
   })
 
   describe('Next Middleware Executor', () => {


### PR DESCRIPTION
## Summary

`lib/utils/queryparams.js` runs on **every request** (and again per nested-router level), so it's squarely on the hot path. Two pieces of per-request work were avoidable, and removing them speeds up query parsing **~36%** with **no behavior change** and no API change.

### 1. Unconditional array-notation regex
`new URLSearchParams(search.replace(/\[\]=/g, '='))` scanned/allocated a regex replacement over every query string, even when no `a[]=` array notation existed. Now gated on a cheap `search.indexOf('[]=')` check.

### 2. Per-parameter allocation for the prototype-pollution guard
`name.split(/[.[\]]+/).filter(Boolean)` allocated a throwaway array **for every parameter on every request**, solely to check for `__proto__` / `prototype` / `constructor` segments. Those are vanishingly rare in real traffic. The split now runs only when the name contains `proto` or `constructor` (a substring superset of all three dangerous keys), so normal parameters skip the allocation entirely.

## Behavior is identical

The dangerous-key filtering and array/repeat grouping are unchanged. Verified by two new tests in `tests/router-coverage.test.js`:
- repeated + `[]=` array notation grouping
- all prototype-pollution key forms (`__proto__`, `prototype`, `user.constructor`, `a[__proto__]`) are stripped, query object stays null-prototype, and `Object.prototype` is not polluted.

I also diffed old-vs-new output across 11 URLs (including every dangerous form) — 0 differences.

## Measured (Node 22, 3M iterations, warmed)

| Input | master | this PR | Δ |
|---|---|---|---|
| `?q=node&page=2&limit=20` | 489 ns/op | 312 ns/op | **−36% / +57% ops/s** |
| `?id[]=1&id[]=2&tag=x` | 595 ns/op | 428 ns/op | **−28%** |
| no query (`/api/users`) | 10.7 ns/op | 10.7 ns/op | unchanged |

## Validation
- Full suite: **71 passing** (was 69 + 2 new tests).
- `lib/utils/queryparams.js`: **100% line coverage**.
- `standard` lint clean.

## Out of scope (deferred)
A second optimization — nested routers re-parse the (identical) query string at every level — was identified but **deliberately deferred**: it requires adding per-request state and a correctness decision about query immutability across the middleware chain. Happy to follow up in a separate PR if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)