### PR TITLE
chore: prep v5.0.1 — version bump + remove TRON donate address

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ server.listen(3000)
 # Support / Donate 💚
 You can support the maintenance of this project: 
 - PayPal: https://www.paypal.me/kyberneees
-- [TRON](https://www.binance.com/en/buy-TRON) Wallet: `TJ5Bbf9v4kpptnRsePXYDvnYcYrS5Tyxus`
 
 # More
 - Website and documentation: https://0http.21no.de

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "0http",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Zero friction HTTP request router. The need for speed!",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Release prep for **v5.0.1** (patch).

## Changes
- **`package.json`**: `5.0.0` → `5.0.1`.
- **`README.md`**: removed the TRON wallet address from the Support / Donate section (PayPal link retained).

## What v5.0.1 ships (since v5.0.0)
- fix: `prioRequestsProcessing` default honored with partial config + cached `req.params` no longer shared across requests (#52)
- perf: ~36% faster query-string parsing on the request hot path, behavior-identical (#53)

No API changes. Suite: 71 passing.

After merge: tag `v5.0.1`, create the GitHub release (notes drafted), and `npm publish`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)